### PR TITLE
Structure View ehancements

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/structure/LuaClassMethodElement.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/structure/LuaClassMethodElement.kt
@@ -23,9 +23,9 @@ import com.tang.intellij.lua.psi.LuaClassMethodDef
 
  * Created by TangZX on 2016/12/13.
  */
-class LuaClassMethodElement internal constructor(methodDef: LuaClassMethodDef) : LuaTreeElement<LuaClassMethodDef>(methodDef, LuaIcons.CLASS_METHOD) {
+open class LuaClassMethodElement internal constructor(methodDef: LuaClassMethodDef) : LuaTreeElement<LuaClassMethodDef>(methodDef, LuaIcons.CLASS_METHOD) {
 
-    private val methodName: String
+    protected var methodName: String
 
     init {
         val methodName = methodDef.classMethodName

--- a/src/main/java/com/tang/intellij/lua/editor/structure/LuaFileElement.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/structure/LuaFileElement.kt
@@ -67,10 +67,65 @@ class LuaFileElement(private val file: LuaFile) : StructureViewTreeElement {
     }
 
     override fun getChildren(): Array<TreeElement> {
+        class ClassTreeElement(indexExpr:LuaPsiElement) : LuaTreeElement<LuaPsiElement>(indexExpr, LuaIcons.CLASS) {
+            val children = ArrayList<TreeElement>()
+            var name = element.name
+
+            override fun getPresentableText(): String? {
+                return name
+            }
+
+            fun addChild(child:TreeElement) {
+                children.add(child)
+            }
+
+            override fun getChildren(): Array<TreeElement> {
+                return children.toTypedArray()
+            }
+
+            fun getChildList():ArrayList<TreeElement> {
+                return children
+            }
+        }
+
+        class ShortMethodElement internal constructor(methodDef: LuaClassMethodDef) : LuaClassMethodElement(methodDef) {
+            init {
+                this.methodName = methodDef.name + methodDef.paramSignature
+            }
+        }
+
+        class ClassStructure(val treeElement:TreeElement?) {
+            val children = HashMap<String, ClassStructure>()
+
+            operator fun get(name:String):ClassStructure? {
+                return children[name]
+            }
+
+            operator fun set(name:String, elem:ClassStructure) {
+                children[name] = elem
+
+                if (treeElement != null && elem.treeElement != null) {
+                    (treeElement as ClassTreeElement).addChild(elem.treeElement)
+                }
+            }
+
+            fun addMethod(mtd:ShortMethodElement) {
+                (treeElement as ClassTreeElement).addChild(mtd)
+            }
+        }
+
+        class LuaNameDefElement internal constructor(val nameDef: LuaNameDef) : LuaTreeElement<LuaNameDef>(nameDef, LuaIcons.LOCAL_VAR) {
+            override fun getPresentableText(): String? {
+                return nameDef.name
+            }
+        }
+
+
+        val locals = HashMap<String, Int>()
         val list = ArrayList<TreeElement>()
+        val classes = ClassStructure(null)
 
-        file.acceptChildren(object : LuaVisitor() {
-
+        val visitor = object : LuaVisitor() {
             internal fun visitDocComment(comment: PsiElement) {
                 comment.acceptChildren(object : LuaDocVisitor() {
                     override fun visitClassDef(o: LuaDocClassDef) {
@@ -100,12 +155,111 @@ class LuaFileElement(private val file: LuaFile) : StructureViewTreeElement {
                 }
             }
 
+            override fun visitCallStat(o: LuaCallStat) {
+                val callExpr = o.firstChild
+                val args = callExpr.lastChild
+                val exprList = args.children[0]
+
+                exprList.accept(this)
+            }
+
+            override fun visitExprList(o: LuaExprList) {
+                o.exprList.forEach{it.accept(this)}
+            }
+
+            override fun visitTableExpr(o: LuaTableExpr) {
+                super.visitTableExpr(o)
+            }
+
+            override fun visitClosureExpr(o: LuaClosureExpr) {
+                o.children[0].accept(this)
+            }
+
+            override fun visitFuncBody(o: LuaFuncBody) {
+                // A func body has, as children, some number of param name defs followed by a block
+                val block = o.children[o.children.size - 1]
+
+                block.accept(this)
+            }
+
+            override fun visitBlock(o: LuaBlock) {
+                o.children.forEach{
+                    if (it is LuaClassMethodDef) {
+                        val classMethodName = it.classMethodName
+
+                        var namePart = classMethodName.firstChild
+                        while (namePart.firstChild is LuaExpr) {
+                            namePart = namePart.firstChild
+                        }
+
+                        var curClassContext = classes
+
+                        while (namePart != classMethodName) {
+                            var name = namePart.lastChild.text
+
+                            if (name == null) {
+                                name = "<null>"
+                            }
+
+                            var curClassStruct = curClassContext[name]
+
+                            if (curClassStruct == null) {
+                                var curClassElem:ClassTreeElement? = null
+
+                                if (curClassContext.treeElement == null && name in locals) {
+                                    val idx = locals[name]
+
+                                    if (idx != null) {
+                                        locals.remove(name)
+                                        val nameDefEle:LuaNameDefElement = list[idx] as LuaNameDefElement
+
+                                        curClassElem = ClassTreeElement(nameDefEle.nameDef)
+
+                                        list.removeAt(idx)
+                                    }
+                                }
+
+                                if (curClassElem == null) {
+                                    curClassElem = ClassTreeElement(namePart as LuaPsiElement)
+                                }
+
+                                curClassStruct = ClassStructure(curClassElem)
+
+                                if (curClassContext.treeElement == null) {
+                                    list.add(curClassElem)
+                                }
+
+                                curClassContext[name] = curClassStruct
+                            }
+
+                            curClassContext = curClassStruct
+                            namePart = namePart.parent
+                        }
+
+                        curClassContext.addMethod(ShortMethodElement(it))
+
+//                        list.add(LuaClassMethodElement(it))
+                    } else {
+                        it.accept(this)
+                    }
+                }
+            }
+
+            override fun visitClassMethod(o: LuaClassMethod) {
+                super.visitClassMethod(o)
+            }
+
             override fun visitLocalDef(o: LuaLocalDef) {
                 val comment = o.comment
                 if (comment != null)
                     visitDocComment(comment)
-                else
-                    list.add(LuaLocalElement(o))
+                else {
+                    o.children[0].children.forEach{nameDef ->
+                        locals[(nameDef as LuaNameDef).name] = list.size
+                        list.add(LuaNameDefElement(nameDef))
+                    }
+//                    list.add(LuaLocalElement(o))
+                }
             }
 
             override fun visitLocalFuncDef(o: LuaLocalFuncDef) {
@@ -115,7 +269,34 @@ class LuaFileElement(private val file: LuaFile) : StructureViewTreeElement {
             override fun visitClassMethodDef(o: LuaClassMethodDef) {
                 list.add(LuaClassMethodElement(o))
             }
-        })
+        }
+
+        file.acceptChildren(visitor)
+
+        // Eliminate empty middle classes
+        fun compressChild(element:TreeElement) {
+            if (element !is ClassTreeElement) {
+                return
+            }
+
+            if (element.children.size == 1) {
+                if (element.children[0] is ClassTreeElement) {
+                    val child = element.children[0] as ClassTreeElement
+
+                    element.name += "." + child.name
+
+                    element.getChildList().clear()
+
+                    child.children.forEach{childElem -> element.addChild(childElem)}
+
+                    compressChild(element)
+                }
+            } else {
+                element.children.forEach{childElem -> compressChild(childElem)}
+            }
+        }
+
+        list.forEach{elem -> compressChild(elem)}
 
         return list.toTypedArray()
     }

--- a/src/main/java/com/tang/intellij/lua/editor/structure/LuaLocalElement.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/structure/LuaLocalElement.kt
@@ -28,7 +28,7 @@ class LuaLocalElement internal constructor(localDef: LuaLocalDef) : LuaTreeEleme
     override fun getPresentableText(): String? {
         val nameList = element.nameList
         if (nameList != null)
-            return "local " + nameList.text
+            return nameList.text
         return null
     }
 }

--- a/src/main/java/com/tang/intellij/lua/editor/structure/LuaLocalFuncElement.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/structure/LuaLocalFuncElement.kt
@@ -25,7 +25,7 @@ import com.tang.intellij.lua.psi.LuaLocalFuncDef
  */
 class LuaLocalFuncElement internal constructor(target: LuaLocalFuncDef) : LuaTreeElement<LuaLocalFuncDef>(target, LuaIcons.LOCAL_FUNCTION) {
 
-    private val name: String = "local function " + element.name + element.paramSignature
+    private val name: String = element.name + element.paramSignature
 
     override fun getPresentableText(): String {
         return name


### PR DESCRIPTION
This is an attempt to populate the structure view with more info.
Changes:
* removed "local" and "local function" from local vars/functions (there is enough information displayed that these annotations aren't needed)
* when multiple local vars are defined on one line (e.g. local foo, bar, baz = ...), they still appear on their lines in the structure view
* Method definitions are nested (e.g. assume methods Obj:foo(), Obj:bar(), Obj.baz(), then it will appear in the view as Obj with 3 children:
  - Obj
    - foo()
    - bar()
    - baz()
* Deeper nesting is handled, e.g. Obj.Foo.Bar:baz() shows up as:
  - Obj
    - Foo
      - Bar
        - baz()
* In situations where the middle references (e.g. Foo and Bar in Obj.Foo.Bar:baz()) don't have any other children., they get collapsed.  So, Obj.Foo.Bar.baz() actually shows up as:
  - Obj.Foo.Bar
    - baz()
* recognizes local vars that are used as objects, e.g.
```
local Obj = {}
function Obj:bar()
``` 
displays as
  - Obj
    - bar()
(clicking on Obj will bring you to the declaration of Obj, clicking on bar() will bring you to the declaration of bar())

I recognize that the classes need to be split out into separate files, etc -- I kept it like this just so that you can comment and let me know if you're interested in my continuing with this effort.