### PR TITLE
Type safety

### DIFF
--- a/gen/com/tang/intellij/lua/psi/LuaTableField.java
+++ b/gen/com/tang/intellij/lua/psi/LuaTableField.java
@@ -47,7 +47,7 @@ public interface LuaTableField extends LuaClassField, PsiNameIdentifierOwner, Lu
   LuaComment getComment();
 
   @Nullable
-  LuaLiteralExpr getIdExpr();
+  LuaExpr getIdExpr();
 
   @Nullable
   PsiElement getLbrack();

--- a/gen/com/tang/intellij/lua/psi/impl/LuaTableFieldImpl.java
+++ b/gen/com/tang/intellij/lua/psi/impl/LuaTableFieldImpl.java
@@ -103,7 +103,7 @@ public class LuaTableFieldImpl extends StubBasedPsiElementBase<LuaTableFieldStub
   }
 
   @Nullable
-  public LuaLiteralExpr getIdExpr() {
+  public LuaExpr getIdExpr() {
     return LuaPsiImplUtilKt.getIdExpr(this);
   }
 

--- a/src/main/java/com/tang/intellij/lua/Constants.java
+++ b/src/main/java/com/tang/intellij/lua/Constants.java
@@ -29,4 +29,9 @@ public class Constants {
     public static final String WORD_ANY = "any";
     public static final String WORD_MODULE = "module";
     public static final String WORD_NIL = "nil";
+    public static final String WORD_STRING = "string";
+    public static final String WORD_BOOLEAN = "boolean";
+    public static final String WORD_NUMBER = "number";
+    public static final String WORD_TABLE = "table";
+    public static final String WORD_FUNCTION = "function";
 }

--- a/src/main/java/com/tang/intellij/lua/Constants.java
+++ b/src/main/java/com/tang/intellij/lua/Constants.java
@@ -28,4 +28,5 @@ public class Constants {
     public static final String WORD_IPAIRS = "ipairs";
     public static final String WORD_ANY = "any";
     public static final String WORD_MODULE = "module";
+    public static final String WORD_NIL = "nil";
 }

--- a/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
+++ b/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
@@ -162,6 +162,10 @@ class LuaAnnotator : Annotator {
                     annotation.textAttributes = if (isModuleFile) LuaHighlightingData.FIELD else LuaHighlightingData.GLOBAL_VAR
                 }
             }
+
+            if (LuaSettings.instance.isEnforceTypeSafety && res == null) {
+                myHolder!!.createErrorAnnotation(o, "Undeclared variable '%s'.".format(o.text))
+            }
         }
 
         private fun checkUpValue(o: LuaNameExpr) {

--- a/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
+++ b/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
@@ -283,7 +283,7 @@ class LuaAnnotator : Annotator {
             // Check individual arguments
             for (i in 0 until concreteParams.size) {
                 // Check if concrete param is subtype of abstract type.
-                var concreteType = concreteTypes[i]
+                val concreteType = concreteTypes[i]
                 val abstractType = abstractParams.params[i].ty
 
                 if (!concreteType.subTypeOf(abstractType, searchContext)) {
@@ -420,12 +420,13 @@ class LuaAnnotator : Annotator {
             val context = SearchContext(o.project)
             val funcDef = PsiTreeUtil.getParentOfType(o, LuaClassMethodDef::class.java)
 
-            if (funcDef == null) {
-                myHolder!!.createErrorAnnotation(o, "Return statement needs to be in function.")
-                return
+            val types = if (funcDef != null) {
+                guessSuperReturnTypes(funcDef, context)
+            } else {
+                val fdef = PsiTreeUtil.getParentOfType(o, LuaFuncDef::class.java)
+                val comment = fdef?.comment?.returnDef
+                comment?.typeList?.tyList?.map { it.getType() } ?: listOf()
             }
-
-            val types = guessSuperReturnTypes(funcDef, context)
 
             // If some return type is defined, we require at least one return type
             val returns = PsiTreeUtil.findChildOfType(o, LuaReturnStat::class.java)

--- a/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
+++ b/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
@@ -313,14 +313,10 @@ class LuaAnnotator : Annotator {
                         val parent = field.guessParentType(searchContext)
 
                         if (parent is TyClass) {
-                            val fieldType = parent.findMemberType(name, searchContext)
+                            val fieldType = parent.findMemberType(name, searchContext) ?: Ty.NIL
 
-                            if (fieldType == null) {
-                                myHolder!!.createErrorAnnotation(field, "No type specified for field %s of class %s.".format(name, parent.displayName))
-                            } else {
-                                if (!valueType.subTypeOf(fieldType, searchContext)) {
-                                    myHolder!!.createErrorAnnotation(value, "Type mismatch. Required: '%s' Found: '%s'".format(fieldType, valueType))
-                                }
+                            if (!valueType.subTypeOf(fieldType, searchContext)) {
+                                myHolder!!.createErrorAnnotation(value, "Type mismatch. Required: '%s' Found: '%s'".format(fieldType, valueType))
                             }
                         }
                     } else {

--- a/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
+++ b/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
@@ -211,8 +211,7 @@ class LuaAnnotator : Annotator {
 
             if (type is TyPsiFunction) {
                 val givenParams = o.args.children.filterIsInstance<LuaExpr>()
-                // TODO: Remove workaround because nil is parsed as TyUnknown
-                val givenTypes = givenParams.map({ param -> if (param.text == "nil") TyNil() else param.guessType(searchContext) })
+                val givenTypes = givenParams.map { param -> param.guessType(searchContext) }
 
                 // Check if there are overloads?
                 if (type.signatures.isEmpty()) {
@@ -273,11 +272,6 @@ class LuaAnnotator : Annotator {
                 // Check if concrete param is subtype of abstract type.
                 var concreteType = concreteTypes[i]
                 val abstractType = abstractParams.params[i].ty
-
-                // TODO: Remove hack because nil is parsed as TyUnknown
-                if (concreteParams[i].text == "nil") {
-                    concreteType = TyNil()
-                }
 
                 if (!concreteType.subTypeOf(abstractType, searchContext)) {
                     return false

--- a/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
+++ b/src/main/java/com/tang/intellij/lua/annotator/LuaAnnotator.kt
@@ -185,6 +185,17 @@ class LuaAnnotator : Annotator {
                     val annotation = myHolder!!.createInfoAnnotation(id, null)
                     if (o.parent is LuaCallExpr) {
                         if (o.colon != null) {
+                            if (LuaSettings.instance.isEnforceTypeSafety) {
+                                // Guess parent types
+                                val context = SearchContext(o.project)
+                                o.exprList.forEach { expr ->
+                                    if (expr.guessType(context) == Ty.NIL) {
+                                        // If parent type is nil add error
+                                        myHolder!!.createErrorAnnotation(expr, "Trying to index a nil type.")
+                                    }
+                                }
+                            }
+
                             annotation.textAttributes = LuaHighlightingData.INSTANCE_METHOD
                         } else {
                             annotation.textAttributes = LuaHighlightingData.STATIC_METHOD
@@ -232,6 +243,8 @@ class LuaAnnotator : Annotator {
                     val errorStr = "No matching overload of type: %s(%s)"
                     myHolder!!.createErrorAnnotation(o, errorStr.format(o.firstChild.text, signatureString))
                 }
+            } else {
+                myHolder!!.createErrorAnnotation(o, "Unknown function '%s'.".format(o.expr.lastChild.text))
             }
         }
 

--- a/src/main/java/com/tang/intellij/lua/codeInsight/LuaLineMarkerProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/codeInsight/LuaLineMarkerProvider.kt
@@ -40,6 +40,7 @@ import com.tang.intellij.lua.psi.search.LuaClassInheritorsSearch
 import com.tang.intellij.lua.psi.search.LuaOverridingMethodsSearch
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.stubs.index.LuaClassMemberIndex
+import com.tang.intellij.lua.ty.TyClass
 
 /**
  * line marker
@@ -60,7 +61,7 @@ class LuaLineMarkerProvider(private val daemonSettings: DaemonCodeAnalyzerSettin
                 val methodName = methodDef.name!!
                 var superType = type.getSuperClass(context)
 
-                while (superType != null) {
+                while (superType != null && superType is TyClass) {
                     val superTypeName = superType.className
                     val superMethod = LuaClassMemberIndex.findMethod(superTypeName, methodName, context)
                     if (superMethod != null) {

--- a/src/main/java/com/tang/intellij/lua/comment/psi/LuaDocPsiImplUtil.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/LuaDocPsiImplUtil.kt
@@ -26,6 +26,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.StubBasedPsiElement
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.util.PsiTreeUtil
+import com.tang.intellij.lua.Constants
 import com.tang.intellij.lua.comment.reference.LuaClassNameReference
 import com.tang.intellij.lua.comment.reference.LuaDocParamNameReference
 import com.tang.intellij.lua.psi.LuaElementFactory
@@ -46,7 +47,16 @@ fun getReference(docClassNameRef: LuaDocClassNameRef): PsiReference {
 }
 
 fun resolveType(nameRef: LuaDocClassNameRef): ITy {
-    return TyLazyClass(nameRef.text)
+    return when (nameRef.text){
+        Constants.WORD_NIL -> Ty.NIL
+        Constants.WORD_ANY -> Ty.UNKNOWN
+        Constants.WORD_BOOLEAN -> Ty.BOOLEAN
+        Constants.WORD_STRING -> Ty.STRING
+        Constants.WORD_NUMBER -> Ty.NUMBER
+        Constants.WORD_TABLE -> Ty.TABLE
+        Constants.WORD_FUNCTION -> Ty.FUNCTION
+        else -> TyLazyClass(nameRef.text)
+    }
 }
 
 fun getName(identifierOwner: PsiNameIdentifierOwner): String? {

--- a/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
@@ -35,4 +35,5 @@ interface LuaComment : PsiComment, LuaDocPsiElement {
     val typeDef: LuaDocTypeDef?
     val returnDef: LuaDocReturnDef?
     fun guessType(context: SearchContext): ITy
+    fun isOverride(): Boolean
 }

--- a/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
@@ -17,10 +17,7 @@
 package com.tang.intellij.lua.comment.psi.api
 
 import com.intellij.psi.PsiComment
-import com.tang.intellij.lua.comment.psi.LuaDocClassDef
-import com.tang.intellij.lua.comment.psi.LuaDocParamDef
-import com.tang.intellij.lua.comment.psi.LuaDocPsiElement
-import com.tang.intellij.lua.comment.psi.LuaDocTypeDef
+import com.tang.intellij.lua.comment.psi.*
 import com.tang.intellij.lua.psi.LuaCommentOwner
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.ty.ITy
@@ -33,6 +30,7 @@ interface LuaComment : PsiComment, LuaDocPsiElement {
     val owner: LuaCommentOwner?
     val moduleName: String?
     fun getParamDef(name: String): LuaDocParamDef?
+    fun getFieldDef(name: String): LuaDocFieldDef?
     val classDef: LuaDocClassDef?
     val typeDef: LuaDocTypeDef?
     fun guessType(context: SearchContext): ITy

--- a/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/api/LuaComment.kt
@@ -33,5 +33,6 @@ interface LuaComment : PsiComment, LuaDocPsiElement {
     fun getFieldDef(name: String): LuaDocFieldDef?
     val classDef: LuaDocClassDef?
     val typeDef: LuaDocTypeDef?
+    val returnDef: LuaDocReturnDef?
     fun guessType(context: SearchContext): ITy
 }

--- a/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
@@ -22,6 +22,7 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.tang.intellij.lua.comment.LuaCommentUtil
 import com.tang.intellij.lua.comment.psi.LuaDocClassDef
+import com.tang.intellij.lua.comment.psi.LuaDocFieldDef
 import com.tang.intellij.lua.comment.psi.LuaDocParamDef
 import com.tang.intellij.lua.comment.psi.LuaDocTypeDef
 import com.tang.intellij.lua.comment.psi.api.LuaComment
@@ -59,6 +60,19 @@ class LuaCommentImpl(charSequence: CharSequence?) : LazyParseablePsiElement(LuaT
             if (element is LuaDocParamDef) {
                 val nameRef = element.paramNameRef
                 if (nameRef != null && nameRef.text == name)
+                    return element
+            }
+            element = element.nextSibling
+        }
+        return null
+    }
+
+    override fun getFieldDef(name: String): LuaDocFieldDef? {
+        var element: PsiElement? = firstChild
+        while (element != null) {
+            if (element is LuaDocFieldDef) {
+                val nameRef = element.fieldName
+                if (nameRef != null && nameRef == name)
                     return element
             }
             element = element.nextSibling

--- a/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
@@ -21,10 +21,7 @@ import com.intellij.psi.impl.source.tree.LazyParseablePsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.tang.intellij.lua.comment.LuaCommentUtil
-import com.tang.intellij.lua.comment.psi.LuaDocClassDef
-import com.tang.intellij.lua.comment.psi.LuaDocFieldDef
-import com.tang.intellij.lua.comment.psi.LuaDocParamDef
-import com.tang.intellij.lua.comment.psi.LuaDocTypeDef
+import com.tang.intellij.lua.comment.psi.*
 import com.tang.intellij.lua.comment.psi.api.LuaComment
 import com.tang.intellij.lua.psi.LuaCommentOwner
 import com.tang.intellij.lua.psi.LuaTypes
@@ -91,6 +88,18 @@ class LuaCommentImpl(charSequence: CharSequence?) : LazyParseablePsiElement(LuaT
         }
         return null
     }
+
+    override val returnDef: LuaDocReturnDef?
+        get() {
+            var element: PsiElement? = firstChild
+            while (element != null) {
+                if (element is LuaDocReturnDef) {
+                    return element
+                }
+                element = element.nextSibling
+            }
+            return null
+        }
 
     override val typeDef: LuaDocTypeDef?
         get() {

--- a/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/impl/LuaCommentImpl.kt
@@ -121,6 +121,17 @@ class LuaCommentImpl(charSequence: CharSequence?) : LazyParseablePsiElement(LuaT
         return typeDef?.type ?: Ty.UNKNOWN
     }
 
+    override fun isOverride(): Boolean {
+        var elem = firstChild
+        while (elem != null) {
+            if (elem is LuaDocTagDef) {
+                if (elem.text == "override") return true
+            }
+            elem = elem.nextSibling
+        }
+        return false
+    }
+
     override fun toString(): String {
         return "DOC_COMMENT"
     }

--- a/src/main/java/com/tang/intellij/lua/editor/LuaNameSuggestionProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/LuaNameSuggestionProvider.kt
@@ -41,7 +41,7 @@ class LuaNameSuggestionProvider : NameSuggestionProvider {
     private fun collectNames(type: ITy, context: SearchContext, collector: (name: String, suffix: String, preferLonger: Boolean) -> Unit) {
         when (type) {
             is ITyClass -> {
-                var cur: ITyClass? = type
+                var cur: ITy? = type
                 while (cur != null) {
                     if (!cur.isAnonymous)
                         collector(fixName(type.className), "", false)

--- a/src/main/java/com/tang/intellij/lua/editor/completion/OverrideCompletionProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/completion/OverrideCompletionProvider.kt
@@ -29,7 +29,9 @@ import com.tang.intellij.lua.lang.LuaIcons
 import com.tang.intellij.lua.psi.*
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.stubs.index.LuaClassMemberIndex
+import com.tang.intellij.lua.ty.ITy
 import com.tang.intellij.lua.ty.ITyClass
+import com.tang.intellij.lua.ty.TyClass
 import com.tang.intellij.lua.ty.TyLazyClass
 
 /**
@@ -54,9 +56,9 @@ class OverrideCompletionProvider : CompletionProvider<CompletionParameters>() {
         }
     }
 
-    private fun addOverrideMethod(completionParameters: CompletionParameters, completionResultSet: CompletionResultSet, memberNameSet:MutableSet<String>, sup: ITyClass?) {
+    private fun addOverrideMethod(completionParameters: CompletionParameters, completionResultSet: CompletionResultSet, memberNameSet:MutableSet<String>, sup: ITy?) {
         var superCls = sup
-        if (superCls != null) {
+        if (superCls != null && superCls is TyClass) {
             val project = completionParameters.originalFile.project
             val context = SearchContext(project)
             val clazzName = superCls.className

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
@@ -44,6 +44,8 @@ class LuaSettings : PersistentStateComponent<LuaSettings> {
     // Throw errors if specified and found types do not match
     var isEnforceTypeSafety: Boolean = false
 
+    var isNilStrict: Boolean = false
+
     override fun getState(): LuaSettings? {
         return this
     }

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
@@ -41,6 +41,9 @@ class LuaSettings : PersistentStateComponent<LuaSettings> {
 
     var isShowWordsInFile: Boolean = true
 
+    // Throw errors if specified and found types do not match
+    var isEnforceTypeSafety: Boolean = false
+
     override fun getState(): LuaSettings? {
         return this
     }

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
@@ -59,7 +59,7 @@
           </component>
         </children>
       </grid>
-      <grid id="9700" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="9700" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -103,6 +103,14 @@
             </constraints>
             <properties>
               <text value="show words in file"/>
+            </properties>
+          </component>
+          <component id="a634e" class="javax.swing.JCheckBox" binding="enforceTypeSafety">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enforce type safety"/>
             </properties>
           </component>
         </children>

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
@@ -59,7 +59,7 @@
           </component>
         </children>
       </grid>
-      <grid id="9700" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="9700" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -111,6 +111,14 @@
             </constraints>
             <properties>
               <text value="Enforce type safety"/>
+            </properties>
+          </component>
+          <component id="1b7b4" class="javax.swing.JCheckBox" binding="nilStrict">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Strict nil checks"/>
             </properties>
           </component>
         </children>

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
@@ -41,6 +41,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
     private JCheckBox smartCloseEnd;
     private JCheckBox showWordsInFile;
     private JCheckBox enforceTypeSafety;
+    private JCheckBox nilStrict;
 
     public LuaSettingsPanel(LuaSettings settings) {
         this.settings = settings;
@@ -49,6 +50,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         smartCloseEnd.setSelected(settings.isSmartCloseEnd());
         showWordsInFile.setSelected(settings.isShowWordsInFile());
         enforceTypeSafety.setSelected(settings.isEnforceTypeSafety());
+        nilStrict.setSelected(settings.isNilStrict());
     }
 
     @NotNull
@@ -75,7 +77,8 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
                 settings.isStrictDoc() != strictDoc.isSelected() ||
                 settings.isSmartCloseEnd() != smartCloseEnd.isSelected() ||
                 settings.isShowWordsInFile() != showWordsInFile.isSelected() ||
-                settings.isEnforceTypeSafety() != enforceTypeSafety.isSelected();
+                settings.isEnforceTypeSafety() != enforceTypeSafety.isSelected() ||
+                settings.isNilStrict() != nilStrict.isSelected();
     }
 
     @Override
@@ -86,6 +89,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         settings.setSmartCloseEnd(smartCloseEnd.isSelected());
         settings.setShowWordsInFile(showWordsInFile.isSelected());
         settings.setEnforceTypeSafety(enforceTypeSafety.isSelected());
+        settings.setNilStrict(nilStrict.isSelected());
 
         for (Project project : ProjectManager.getInstance().getOpenProjects()) {
             DaemonCodeAnalyzer.getInstance(project).restart();

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
@@ -40,6 +40,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
     private JCheckBox strictDoc;
     private JCheckBox smartCloseEnd;
     private JCheckBox showWordsInFile;
+    private JCheckBox enforceTypeSafety;
 
     public LuaSettingsPanel(LuaSettings settings) {
         this.settings = settings;
@@ -47,6 +48,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         strictDoc.setSelected(settings.isStrictDoc());
         smartCloseEnd.setSelected(settings.isSmartCloseEnd());
         showWordsInFile.setSelected(settings.isShowWordsInFile());
+        enforceTypeSafety.setSelected(settings.isEnforceTypeSafety());
     }
 
     @NotNull
@@ -72,7 +74,8 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         return !StringUtil.equals(settings.getConstructorNamesString(), constructorNames.getText()) ||
                 settings.isStrictDoc() != strictDoc.isSelected() ||
                 settings.isSmartCloseEnd() != smartCloseEnd.isSelected() ||
-                settings.isShowWordsInFile() != showWordsInFile.isSelected();
+                settings.isShowWordsInFile() != showWordsInFile.isSelected() ||
+                settings.isEnforceTypeSafety() != enforceTypeSafety.isSelected();
     }
 
     @Override
@@ -82,6 +85,7 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         settings.setStrictDoc(strictDoc.isSelected());
         settings.setSmartCloseEnd(smartCloseEnd.isSelected());
         settings.setShowWordsInFile(showWordsInFile.isSelected());
+        settings.setEnforceTypeSafety(enforceTypeSafety.isSelected());
 
         for (Project project : ProjectManager.getInstance().getOpenProjects()) {
             DaemonCodeAnalyzer.getInstance(project).restart();

--- a/src/main/java/com/tang/intellij/lua/psi/LuaPsiImplUtil.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/LuaPsiImplUtil.kt
@@ -585,12 +585,10 @@ fun getPresentation(tableField: LuaTableField): ItemPresentation {
 /**
  * xx['id']
  */
-fun getIdExpr(tableField: LuaTableField): LuaLiteralExpr? {
+fun getIdExpr(tableField: LuaTableField): LuaExpr? {
     val bracket = tableField.lbrack
     if (bracket != null) {
-        val nextLeaf = PsiTreeUtil.getNextSiblingOfType(bracket, LuaExpr::class.java)
-        if (nextLeaf is LuaLiteralExpr && nextLeaf.kind == LuaLiteralKind.String)
-            return nextLeaf
+        return PsiTreeUtil.getNextSiblingOfType(bracket, LuaExpr::class.java)
     }
     return null
 }

--- a/src/main/java/com/tang/intellij/lua/psi/LuaPsiResolveUtil.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/LuaPsiResolveUtil.kt
@@ -254,11 +254,11 @@ private fun resolveParamType(paramNameDef: LuaParamNameDef, context: SearchConte
 
         // 如果是个类方法，则有可能在父类里
         if (owner is LuaClassMethodDef) {
-            var classType = owner.guessClassType(context)
+            var classType: ITy? = owner.guessClassType(context)
             val methodName = owner.name
             while (classType != null) {
                 classType = classType.getSuperClass(context)
-                if (classType != null && methodName != null) {
+                if (classType != null && methodName != null && classType is TyClass) {
                     val superMethod = classType.findMember(methodName, context)
                     if (superMethod is LuaClassMethod) {
                         val params = superMethod.params//todo : 优化

--- a/src/main/java/com/tang/intellij/lua/psi/impl/LuaExprMixin.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/impl/LuaExprMixin.kt
@@ -24,6 +24,7 @@ import com.tang.intellij.lua.project.LuaSettings
 import com.tang.intellij.lua.psi.*
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.ty.*
+import org.jaxen.expr.UnaryExpr
 
 /**
  * 表达式基类
@@ -39,6 +40,7 @@ open class LuaExprMixin internal constructor(node: ASTNode) : LuaPsiElementImpl(
                 is LuaLiteralExpr -> guessType(this)
                 is LuaClosureExpr -> asTy(context)
                 is LuaBinaryExpr -> guessType(this)
+                is LuaUnaryExpr -> guessType(this, context)
                 else -> Ty.UNKNOWN
             }
         }
@@ -63,6 +65,16 @@ open class LuaExprMixin internal constructor(node: ASTNode) : LuaPsiElementImpl(
             }
         }
         return ty
+    }
+
+    private fun guessType(unaryExpr: LuaUnaryExpr, context: SearchContext): ITy {
+        val operator = unaryExpr.unaryOp.node.firstChildNode.elementType
+
+        return when (operator) {
+            LuaTypes.MINUS -> unaryExpr.expr?.guessType(context) ?: Ty.UNKNOWN // Negative something
+            LuaTypes.GETN -> Ty.NUMBER // Table length is a number
+            else -> Ty.UNKNOWN
+        }
     }
 
     private fun guessType(literalExpr: LuaLiteralExpr): ITy {

--- a/src/main/java/com/tang/intellij/lua/psi/impl/LuaExprMixin.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/impl/LuaExprMixin.kt
@@ -71,6 +71,7 @@ open class LuaExprMixin internal constructor(node: ASTNode) : LuaPsiElementImpl(
             LuaTypes.TRUE ,LuaTypes.FALSE -> Ty.BOOLEAN
             LuaTypes.STRING -> Ty.STRING
             LuaTypes.NUMBER -> Ty.NUMBER
+            LuaTypes.NIL -> Ty.NIL
             else -> Ty.UNKNOWN
         }
     }

--- a/src/main/java/com/tang/intellij/lua/psi/impl/LuaNameExprMixin.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/impl/LuaNameExprMixin.kt
@@ -23,12 +23,14 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.tree.IElementType
+import com.tang.intellij.lua.project.LuaSettings
 import com.tang.intellij.lua.psi.*
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.stubs.LuaNameStub
 import com.tang.intellij.lua.ty.ITy
 import com.tang.intellij.lua.ty.Ty
 import com.tang.intellij.lua.ty.TyClass
+import com.tang.intellij.lua.ty.TyFlags
 
 /**
 
@@ -72,7 +74,7 @@ abstract class LuaNameExprMixin : StubBasedPsiElementBase<LuaNameStub>, LuaExpr,
     private fun getTypeSet(context: SearchContext, def: PsiElement): ITy {
         when (def) {
             is LuaNameExpr -> {
-                var typeSet: ITy = Ty.UNKNOWN
+                var typeSet: ITy = if (!LuaSettings.instance.isEnforceTypeSafety) Ty.UNKNOWN else Ty.NIL
                 val p1 = def.parent // should be VAR_LIST
                 val p2 = p1.parent // should be ASSIGN_STAT
                 if (p2 is LuaAssignStat) {
@@ -92,7 +94,8 @@ abstract class LuaNameExprMixin : StubBasedPsiElementBase<LuaNameStub>, LuaExpr,
 
                 //Global
                 if (isGlobal(def)) {
-                    typeSet = typeSet.union(TyClass.createGlobalType(def))
+                    if (!LuaSettings.instance.isEnforceTypeSafety) typeSet = typeSet.union(TyClass.createGlobalType(def))
+                    if (typeSet is Ty) typeSet.addFlag(TyFlags.GLOBAL)
                 }
                 return typeSet
             }

--- a/src/main/java/com/tang/intellij/lua/psi/impl/LuaTableExprMixin.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/impl/LuaTableExprMixin.kt
@@ -22,10 +22,10 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.tree.IElementType
 import com.tang.intellij.lua.psi.LuaExpr
 import com.tang.intellij.lua.psi.LuaTableExpr
+import com.tang.intellij.lua.psi.LuaTableField
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.stubs.LuaTableStub
-import com.tang.intellij.lua.ty.Ty
-import com.tang.intellij.lua.ty.TyTable
+import com.tang.intellij.lua.ty.*
 
 /**
 
@@ -39,6 +39,20 @@ open class LuaTableExprMixin : StubBasedPsiElementBase<LuaTableStub>, LuaExpr {
     constructor(stub: LuaTableStub, nodeType: IElementType, node: ASTNode) : super(stub, nodeType, node)
 
     override fun guessType(context: SearchContext): Ty {
-        return TyTable(this as LuaTableExpr)
+        val table = this as LuaTableExpr
+        // Check for list syntax {a,b,c}
+        val isList = table.tableFieldList.size > 0 && table.tableFieldList.all { field -> field.exprList.size == 1 }
+
+        // Resolve type
+        if (isList) {
+            var baseType : ITy = Ty.UNKNOWN
+            for (field in table.tableFieldList) {
+                baseType = TyUnion.union(baseType, field.guessType(context))
+            }
+            return TyArray(baseType)
+        }
+
+        // Otherwise return table
+        return TyTable(table)
     }
 }

--- a/src/main/java/com/tang/intellij/lua/ty/Ty.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Ty.kt
@@ -257,7 +257,7 @@ class TyArray(override val base: ITy) : Ty(TyKind.Array), ITyArray {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
-        return super.subTypeOf(other, context) || (other is TyArray && base.subTypeOf(other.base, context)) || other.displayName == "table"
+        return super.subTypeOf(other, context) || (other is TyArray && base.subTypeOf(other.base, context)) || other == Ty.TABLE
     }
 }
 

--- a/src/main/java/com/tang/intellij/lua/ty/Ty.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Ty.kt
@@ -29,7 +29,8 @@ enum class TyKind {
     Function,
     Class,
     Union,
-    Generic
+    Generic,
+    Nil
 }
 enum class TyPrimitiveKind {
     String,
@@ -99,6 +100,9 @@ abstract class Ty(override val kind: TyKind) : ITy {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        // Everything is subset of any
+        if (other.kind == TyKind.Unknown) return true
+
         return this.displayName.equals(other.displayName);
     }
 
@@ -108,6 +112,7 @@ abstract class Ty(override val kind: TyKind) : ITy {
         val BOOLEAN = TyPrimitive(TyPrimitiveKind.Boolean, "boolean")
         val STRING = TyPrimitive(TyPrimitiveKind.String, "string")
         val NUMBER = TyPrimitive(TyPrimitiveKind.Number, "number")
+        val NIL = TyNil()
 
         private fun getPrimitive(mark: Byte): Ty {
             return when (mark.toInt()) {
@@ -235,6 +240,10 @@ class TyArray(override val base: ITy) : Ty(TyKind.Array), ITyArray {
     override fun hashCode(): Int {
         return displayName.hashCode()
     }
+
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        return other == this || other.displayName == "table"
+    }
 }
 
 class TyUnion : Ty(TyKind.Union) {
@@ -337,5 +346,16 @@ class TyUnknown : Ty(TyKind.Unknown) {
 
     override fun hashCode(): Int {
         return Constants.WORD_ANY.hashCode()
+    }
+}
+
+class TyNil : Ty(TyKind.Nil) {
+    override val displayName: String
+        get() = Constants.WORD_NIL
+
+    // Nil only subtype of nil and any
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        // displayName workaround
+        return other.kind == TyKind.Nil || other.kind == TyKind.Unknown || other.displayName == "any"
     }
 }

--- a/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
@@ -107,10 +107,14 @@ abstract class TyClass(override val className: String, override var superClassNa
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        // If other class is any, everything is subclass - TyKind.Unknown == any
+        // displayname is a hack because 'any' is read as class with name 'any'
+        if (other.kind == TyKind.Unknown || other.displayName == "any") return true
+
         // Check if other is also a class
         if (other !is ITyClass) return false
-        // If other class is any, everything is subclass - Maybe add TyKind.Any?
-        if (other.displayName.equals("any")) return true
+
+        if (this == other) return true
 
         // Lazy init for superclass
         this.doLazyInit(context)

--- a/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
@@ -106,6 +106,24 @@ abstract class TyClass(override val className: String, override var superClassNa
         return null
     }
 
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        // Check if other is also a class
+        if (other !is ITyClass) return false
+        // If other class is any, everything is subclass - Maybe add TyKind.Any?
+        if (other.displayName.equals("any")) return true
+
+        // Lazy init for superclass
+        this.doLazyInit(context)
+        // Check if any of the superclasses are type
+        var superClass = getSuperClass(context)
+        while (superClass != null) {
+            if (other == superClass) return true
+            superClass = superClass.getSuperClass(context)
+        }
+
+        return false
+    }
+
     companion object {
         // for _G
         val G: TyClass = TySerializedClass(Constants.WORD_G)

--- a/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
@@ -107,14 +107,7 @@ abstract class TyClass(override val className: String, override var superClassNa
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
-        // If other class is any, everything is subclass - TyKind.Unknown == any
-        // displayname is a hack because 'any' is read as class with name 'any'
-        if (other.kind == TyKind.Unknown || other.displayName == "any") return true
-
-        // Check if other is also a class
-        if (other !is ITyClass) return false
-
-        if (this == other) return true
+        if (super.subTypeOf(other, context)) return true
 
         // Lazy init for superclass
         this.doLazyInit(context)
@@ -191,4 +184,8 @@ class TyTable(val table: LuaTableExpr) : TyClass(getTableTypeName(table)) {
     override fun toString(): String = displayName
 
     override fun doLazyInit(searchContext: SearchContext) = Unit
+
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        return super.subTypeOf(other, context) || other.displayName == "table"
+    }
 }

--- a/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
@@ -166,7 +166,7 @@ abstract class TyFunction : Ty(TyKind.Function), ITyFunction {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
-        if (super.subTypeOf(other, context) || other.displayName == "function") return true // 'any' equivalent for functions
+        if (super.subTypeOf(other, context) || other == Ty.FUNCTION) return true // Subtype of function primitive.
         if (other is ITyFunction) {
             if (mainSignature == other.mainSignature || other.signatures.any({ sig -> sig == mainSignature})) return true
             return signatures.any({ sig -> sig == other.mainSignature || other.signatures.any({ sig2 -> sig2 == sig})})

--- a/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
@@ -166,7 +166,7 @@ abstract class TyFunction : Ty(TyKind.Function), ITyFunction {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
-        if (other.displayName == "function") return true // 'any' equivalent for functions
+        if (super.subTypeOf(other, context) || other.displayName == "function") return true // 'any' equivalent for functions
         if (other is ITyFunction) {
             if (mainSignature == other.mainSignature || other.signatures.any({ sig -> sig == mainSignature})) return true
             return signatures.any({ sig -> sig == other.mainSignature || other.signatures.any({ sig2 -> sig2 == sig})})

--- a/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyFunction.kt
@@ -164,6 +164,15 @@ abstract class TyFunction : Ty(TyKind.Function), ITyFunction {
         }
         return code
     }
+
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        if (other.displayName == "function") return true // 'any' equivalent for functions
+        if (other is ITyFunction) {
+            if (mainSignature == other.mainSignature || other.signatures.any({ sig -> sig == mainSignature})) return true
+            return signatures.any({ sig -> sig == other.mainSignature || other.signatures.any({ sig2 -> sig2 == sig})})
+        }
+        return false
+    }
 }
 
 class TyPsiFunction(private val selfCall: Boolean, val psi: LuaFuncBodyOwner, searchContext: SearchContext, flags: Int = 0) : TyFunction() {

--- a/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
@@ -46,6 +46,7 @@ abstract class TyGeneric : Ty(TyKind.Generic), ITyGeneric {
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
         if (super.subTypeOf(other, context)) return true
+        if (other !is TyGeneric && base.subTypeOf(other, context)) return true
         return other is TyGeneric
                 && base.subTypeOf(other.base, context) // Base should be subtype of other base
                 && params.size == other.params.size // Equal amount of params

--- a/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
@@ -43,6 +43,10 @@ abstract class TyGeneric : Ty(TyKind.Generic), ITyGeneric {
     override fun hashCode(): Int {
         return displayName.hashCode()
     }
+
+    override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
+        return base.subTypeOf(other, context)
+    }
 }
 
 class TyDocGeneric(luaDocGenericTy: LuaDocGenericTy) : TyGeneric() {

--- a/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyGeneric.kt
@@ -45,7 +45,12 @@ abstract class TyGeneric : Ty(TyKind.Generic), ITyGeneric {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext): Boolean {
-        return base.subTypeOf(other, context)
+        if (super.subTypeOf(other, context)) return true
+        return other is TyGeneric
+                && base.subTypeOf(other.base, context) // Base should be subtype of other base
+                && params.size == other.params.size // Equal amount of params
+                && params.indices.all({ i -> params[i].subTypeOf(other.params[i], context) }) // Params need to be subtypes
+
     }
 }
 

--- a/src/main/testData/typeSafety/typeSafety.lua
+++ b/src/main/testData/typeSafety/typeSafety.lua
@@ -1,0 +1,40 @@
+---
+--- Created by Perry.
+--- DateTime: 30-9-2017 20:56
+---
+
+--- Basic test
+--- @param x number
+function test(x) end
+
+test("3") -- Type mismatch, string instead of number
+test(nil) -- Type mismatch, nil instead of number (Only if strict nil option is checked)
+test(3) -- Valid
+test(4, 5) -- Too many arguments
+test() -- Not enough arguments
+
+--- Union test
+--- @param x number | nil
+function test2(x) end
+
+test2(3) -- Valid
+test2(nil) -- Valid
+test2("") -- Type mismatch, string instead of number or nil
+
+--- Overload test
+--- @overload fun(x: number, y: string): boolean
+--- @param x number
+function test3(x) end
+
+test3(3) -- Valid, main signature
+test3(3, "4") -- Valid, overload
+test3(3, 4, 5) -- No matching overload
+test3("") -- No matching overload
+
+--- List test
+--- @param x number[]
+function testList(x) end
+
+--- @type number[]
+local list = {1,2,3}
+testList(list) --- Valid


### PR DESCRIPTION
Initial stable version of the type safety implementation. The extra checks are activated by enabling the type safety checkbox in the plugin settings. Additionally there is an extra setting that enables strict nil checking, meaning nil can not be assigned to types that are not nil or a union with nil.

A TyNil type class was added to denote the nil type, it would be nice if the parser could parse the keyword 'nil' as TyNil instead of TyUnknown, that would allow me to remove some workarounds.

A list of feature requests related to this can be found in #60 .